### PR TITLE
feat: add audio streams placeholder

### DIFF
--- a/frontend/js/app/audio-streams/main.ejs
+++ b/frontend/js/app/audio-streams/main.ejs
@@ -1,0 +1,8 @@
+<div class="page-header">
+    <h1 class="page-title"><%- i18n('audio-streams', 'title') %></h1>
+</div>
+<div class="card">
+    <div class="card-body">
+        <p>Функция аудио стримов находится в разработке.</p>
+    </div>
+</div>

--- a/frontend/js/app/audio-streams/main.js
+++ b/frontend/js/app/audio-streams/main.js
@@ -1,0 +1,14 @@
+const Mn   = require('backbone.marionette');
+const App  = require('../main');
+const tpl  = require('./main.ejs');
+
+// Простое представление страницы аудио стримов
+module.exports = Mn.View.extend({
+    id:       'audio-streams',
+    template: tpl,
+
+    onRender: function () {
+        // Логирование для отладки
+        console.log('Audio Streams view rendered');
+    }
+});

--- a/frontend/js/app/controller.js
+++ b/frontend/js/app/controller.js
@@ -210,13 +210,24 @@ module.exports = {
 	 *
 	 * @param model
 	 */
-	showNginxStreamDeleteConfirm: function (model) {
-		if (Cache.User.isAdmin() || Cache.User.canManage('streams')) {
-			require(['./main', './nginx/stream/delete'], function (App, View) {
-				App.UI.showModalDialog(new View({model: model}));
-			});
-		}
-	},
+        showNginxStreamDeleteConfirm: function (model) {
+                if (Cache.User.isAdmin() || Cache.User.canManage('streams')) {
+                        require(['./main', './nginx/stream/delete'], function (App, View) {
+                                App.UI.showModalDialog(new View({model: model}));
+                        });
+                }
+        },
+
+        /**
+         * Audio Streams page
+         */
+        showAudioStreams: function () {
+                const controller = this;
+                require(['./main', './audio-streams/main'], (App, View) => {
+                        controller.navigate('/audio/streams');
+                        App.UI.showAppContent(new View());
+                });
+        },
 
 	/**
 	 * Nginx Dead Hosts

--- a/frontend/js/app/dashboard/main.ejs
+++ b/frontend/js/app/dashboard/main.ejs
@@ -65,3 +65,18 @@
     <% } %>
 </div>
 <% } %>
+
+<div class="row mt-3">
+    <div class="col-sm-6 col-lg-3">
+        <div class="card p-3">
+            <div class="d-flex align-items-center">
+                <span class="stamp stamp-md bg-purple mr-3">
+                    <i class="fe fe-music"></i>
+                </span>
+                <div>
+                    <h4 class="m-0"><a href="/audio/streams"><%- getHostStat('audio_stream') %> <small><%- i18n('audio-streams', 'title') %></small></a></h4>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/frontend/js/app/router.js
+++ b/frontend/js/app/router.js
@@ -16,6 +16,7 @@ module.exports = AppRouter.default.extend({
         'settings':           'showSettings',
         'services':           'showServices',
         'multiplexor':        'showMultiplexor',
+        'audio/streams':      'showAudioStreams',
         '*default':           'showDashboard'
     }
 });

--- a/frontend/js/app/ui/menu/main.ejs
+++ b/frontend/js/app/ui/menu/main.ejs
@@ -26,6 +26,8 @@
                         <% if (canShow('streams')) { %>
                         <a href="/nginx/stream" class="dropdown-item "><%- i18n('streams', 'title') %></a>
                         <% } %>
+
+                        <a href="/audio/streams" class="dropdown-item"><%- i18n('audio-streams', 'title') %></a>
                     </div>
                 </li>
                 <% if (canShow('access_lists')) { %>

--- a/frontend/js/i18n/en-lang.json
+++ b/frontend/js/i18n/en-lang.json
@@ -253,6 +253,9 @@
     "udp": "UDP",
     "udp-forwarding": "UDP Forwarding"
   },
+  "audio-streams": {
+    "title": "Audio Streams"
+  },
   "tls": {
     "certbot": "Certbot",
     "certbot-agree": "I Agree to the <a href=\"{url}\" target=\"_blank\">Let's Encrypt Terms of Service</a> / ToS of custom set CA",

--- a/frontend/js/i18n/ru-lang.json
+++ b/frontend/js/i18n/ru-lang.json
@@ -253,6 +253,9 @@
     "udp": "UDP",
     "udp-forwarding": "UDP-переадресация"
   },
+  "audio-streams": {
+    "title": "Аудио стримы"
+  },
   "tls": {
     "certbot": "Certbot",
     "certbot-agree": "Я принимаю <a href=\"{url}\" target=\"_blank\">условия Let's Encrypt</a> / условия пользовательского ЦС",


### PR DESCRIPTION
## Summary
- add audio streams link in menu and dashboard
- stub audio streams page and routing

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm --prefix backend run validate-schema`
- `npm --prefix frontend run build`


------
https://chatgpt.com/codex/tasks/task_e_688b4b52241c83258f2bd394f0cdf98c