### PR TITLE
feat(audio-streams): add basic API and frontend list

### DIFF
--- a/backend/routes/audio-streams.js
+++ b/backend/routes/audio-streams.js
@@ -1,0 +1,32 @@
+const express = require('express');
+
+// Простая реализация API для аудио стримов
+// Пока что возвращает статический список для разработки
+let router = express.Router({
+        caseSensitive: true,
+        strict: true,
+        mergeParams: true,
+});
+
+/**
+ * /api/audio-streams
+ */
+router
+        .route('/')
+        .get((req, res) => {
+                res.status(200).send([
+                        {
+                                id: 1,
+                                name: 'Demo Stream',
+                                url: 'http://example.com/stream',
+                                format: 'mp3',
+                                bitrate: 128,
+                                token_type: 'not_used',
+                                token: '',
+                                token_mask: '',
+                                buffer: 0,
+                        },
+                ]);
+        });
+
+module.exports = router;

--- a/backend/routes/main.js
+++ b/backend/routes/main.js
@@ -31,6 +31,7 @@ router.use('/nginx/streams', require('./nginx/streams'));
 router.use('/nginx/access-lists', require('./nginx/access_lists'));
 router.use('/nginx/certificates', require('./nginx/certificates'));
 router.use('/services', require('./services'));
+router.use('/audio-streams', require('./audio-streams'));
 
 /**
  * API 404 for all other routes

--- a/frontend/js/app/audio-streams/main.ejs
+++ b/frontend/js/app/audio-streams/main.ejs
@@ -4,5 +4,6 @@
 <div class="card">
     <div class="card-body">
         <p>Функция аудио стримов находится в разработке.</p>
+        <ul id="audio-stream-list"></ul>
     </div>
 </div>

--- a/frontend/js/app/audio-streams/main.js
+++ b/frontend/js/app/audio-streams/main.js
@@ -1,14 +1,48 @@
-const Mn   = require('backbone.marionette');
-const App  = require('../main');
-const tpl  = require('./main.ejs');
+const Mn  = require('backbone.marionette');
+const App = require('../main');
+const tpl = require('./main.ejs');
 
-// Простое представление страницы аудио стримов
+// Представление страницы аудио стримов
 module.exports = Mn.View.extend({
     id:       'audio-streams',
     template: tpl,
 
+    initialize: function () {
+        // Список стримов будет храниться в памяти
+        this.streams = [];
+    },
+
     onRender: function () {
+        const view = this;
         // Логирование для отладки
         console.log('Audio Streams view rendered');
-    }
+
+        // Получаем список аудио потоков с API
+        fetch('/api/audio-streams')
+            .then((response) => response.json())
+            .then((data) => {
+                view.streams = data;
+                view.renderStreams();
+            })
+            .catch((err) => {
+                console.error('Failed to load audio streams', err);
+            });
+    },
+
+    // Простейший рендер списка потоков
+    renderStreams: function () {
+        const list = this.el.querySelector('#audio-stream-list');
+        if (!list) {
+            return;
+        }
+
+        // Очищаем список
+        list.innerHTML = '';
+
+        this.streams.forEach((stream) => {
+            const li = document.createElement('li');
+            li.textContent = stream.name + ' - ' + stream.url;
+            list.appendChild(li);
+        });
+    },
 });


### PR DESCRIPTION
## Summary
- add temporary `/api/audio-streams` endpoint returning demo stream
- extend main router to expose new audio stream API
- update audio streams page to fetch and display list from API

## Testing
- `npm --prefix backend run validate-schema`

------
https://chatgpt.com/codex/tasks/task_e_688b510bcd088325bc52d96555c7fcd5