### PR TITLE
feat: add audio stream endpoints and fix multiplexor rendering

### DIFF
--- a/backend/routes/audio-streams.js
+++ b/backend/routes/audio-streams.js
@@ -1,12 +1,28 @@
 const express = require('express');
 
 // Простая реализация API для аудио стримов
-// Пока что возвращает статический список для разработки
+// На данном этапе данные хранятся только в памяти
 let router = express.Router({
         caseSensitive: true,
         strict: true,
         mergeParams: true,
 });
+
+// Временное хранилище добавленных потоков
+// В дальнейшем это будет заменено на базу данных
+let streams = [
+        {
+                id:         1,
+                name:       'Demo Stream',
+                url:        'http://example.com/stream',
+                format:     'mp3',
+                bitrate:    128,
+                token_type: 'not_used',
+                token:      '',
+                token_mask: '',
+                buffer:     0,
+        },
+];
 
 /**
  * /api/audio-streams
@@ -14,19 +30,34 @@ let router = express.Router({
 router
         .route('/')
         .get((req, res) => {
-                res.status(200).send([
-                        {
-                                id: 1,
-                                name: 'Demo Stream',
-                                url: 'http://example.com/stream',
-                                format: 'mp3',
-                                bitrate: 128,
-                                token_type: 'not_used',
-                                token: '',
-                                token_mask: '',
-                                buffer: 0,
-                        },
-                ]);
+                // Возвращаем все сохраненные потоки
+                res.status(200).send(streams);
         });
+
+/**
+ * Импорт аудио потоков из плейлистов
+ * Принимает массив объектов {name, url}
+ */
+router.post('/import', express.json(), (req, res) => {
+        const items = Array.isArray(req.body) ? req.body : [];
+        const added = items.map((item, idx) => {
+                // простое назначение id
+                const stream = {
+                        id:         streams.length + idx + 1,
+                        name:       item.name || `Stream ${streams.length + idx + 1}`,
+                        url:        item.url || '',
+                        format:     item.format || '',
+                        bitrate:    item.bitrate || 0,
+                        token_type: item.token_type || 'not_used',
+                        token:      item.token || '',
+                        token_mask: item.token_mask || '',
+                        buffer:     typeof item.buffer === 'number' ? item.buffer : 0,
+                };
+                streams.push(stream);
+                return stream;
+        });
+
+        res.status(200).send(added);
+});
 
 module.exports = router;

--- a/frontend/js/app/multiplexor/main.ejs
+++ b/frontend/js/app/multiplexor/main.ejs
@@ -329,19 +329,19 @@
 
                     // Create service cards in a grid
                     window.multiplexorServices.services.forEach(service => {
-                        const isActive = activeMatches.includes(service.match);
+                        const serviceActive = activeMatches.includes(service.match);
                         const serviceCol = $('<div class="col-md-4 col-lg-3 mb-4"></div>');
 
                         const card = $(`
-                            <div class="card ${isActive ? 'bg-primary text-white' : ''}" style="cursor: pointer;">
+                            <div class="card ${serviceActive ? 'bg-primary text-white' : ''}" style="cursor: pointer;">
                                 <div class="card-body p-3">
                                     <div class="d-flex align-items-center">
-                                        <span class="stamp stamp-md mr-3 ${isActive ? 'bg-white text-primary' : 'bg-primary'}">
+                                        <span class="stamp stamp-md mr-3 ${serviceActive ? 'bg-white text-primary' : 'bg-primary'}">
                                             <i class="${service.icon}"></i>
                                         </span>
                                         <div>
                                             <h4 class="m-0">${service.name}</h4>
-                                            <small class="${isActive ? 'text-white' : 'text-muted'}">${service.description}</small>
+                                            <small class="${serviceActive ? 'text-white' : 'text-muted'}">${service.description}</small>
                                         </div>
                                     </div>
                                 </div>
@@ -349,7 +349,7 @@
                         `);
 
                         card.on('click', function() {
-                            toggleService(service, !isActive);
+                            toggleService(service, !serviceActive);
                         });
 
                         serviceCol.append(card);

--- a/mplex/shoes/services.js
+++ b/mplex/shoes/services.js
@@ -84,21 +84,21 @@ class MultiplexorServices {
         container.innerHTML = '';
 
         this.services.forEach(service => {
-            const isActive = activeServices.includes(service.id);
+            const serviceActive = activeServices.includes(service.id);
 
             const card = document.createElement('div');
-            card.className = `card ${isActive ? 'bg-primary text-white' : ''}`;
+            card.className = `card ${serviceActive ? 'bg-primary text-white' : ''}`;
             card.style.cursor = 'pointer';
 
             card.innerHTML = `
                 <div class="card-body p-3">
                     <div class="d-flex align-items-center">
-                        <span class="stamp stamp-md mr-3 ${isActive ? 'bg-white text-primary' : 'bg-primary'}">
+                        <span class="stamp stamp-md mr-3 ${serviceActive ? 'bg-white text-primary' : 'bg-primary'}">
                             <i class="${service.icon}"></i>
                         </span>
                         <div>
                             <h4 class="m-0">${service.name}</h4>
-                            <small class="${isActive ? 'text-white' : 'text-muted'}">${service.description}</small>
+                            <small class="${serviceActive ? 'text-white' : 'text-muted'}">${service.description}</small>
                         </div>
                     </div>
                 </div>
@@ -106,7 +106,7 @@ class MultiplexorServices {
 
             card.addEventListener('click', () => {
                 if (typeof onToggle === 'function') {
-                    onToggle(service, !isActive);
+                    onToggle(service, !serviceActive);
                 }
             });
 


### PR DESCRIPTION
## Summary
- расширено API аудиостримов: теперь данные сохраняются в памяти и реализован импорт
- исправлена ошибка `isActive` на странице мультиплексора

## Testing
- `npm test` (backend) *(ожидаемо отсутствует тестовый скрипт)*
- `npm test` (frontend) *(ожидаемо отсутствует тестовый скрипт)*

------
https://chatgpt.com/codex/tasks/task_e_688b6ff396348325a9ca00f17ebd73ed