### PR TITLE
fix: handle service active state in multiplexer

### DIFF
--- a/frontend/js/app/multiplexor/main.ejs
+++ b/frontend/js/app/multiplexor/main.ejs
@@ -329,27 +329,35 @@
 
                     // Create service cards in a grid
                     window.multiplexorServices.services.forEach(service => {
-                        const serviceActive = activeMatches.includes(service.match);
+                        // Determine active state for this service
+                        const isActive = activeMatches.includes(service.match);
                         const serviceCol = $('<div class="col-md-4 col-lg-3 mb-4"></div>');
 
                         const card = $(`
-                            <div class="card ${serviceActive ? 'bg-primary text-white' : ''}" style="cursor: pointer;">
+                            <div class="card ${isActive ? 'bg-primary text-white' : ''}" style="cursor: pointer;">
                                 <div class="card-body p-3">
                                     <div class="d-flex align-items-center">
-                                        <span class="stamp stamp-md mr-3 ${serviceActive ? 'bg-white text-primary' : 'bg-primary'}">
+                                        <span class="stamp stamp-md mr-3 ${isActive ? 'bg-white text-primary' : 'bg-primary'}">
                                             <i class="${service.icon}"></i>
                                         </span>
                                         <div>
                                             <h4 class="m-0">${service.name}</h4>
-                                            <small class="${serviceActive ? 'text-white' : 'text-muted'}">${service.description}</small>
+                                            <small class="${isActive ? 'text-white' : 'text-muted'}">${service.description}</small>
                                         </div>
                                     </div>
                                 </div>
                             </div>
                         `);
 
+                        // store state on the element for later access in the handler
+                        card.data('active', isActive);
+                        console.debug('Render card', service.match, 'active:', isActive);
+
                         card.on('click', function() {
-                            toggleService(service, !serviceActive);
+                            const current = $(this).data('active');
+                            console.debug('Toggle card', service.match, '->', !current);
+                            $(this).data('active', !current);
+                            toggleService(service, !current);
                         });
 
                         serviceCol.append(card);

--- a/mplex/shoes/services.js
+++ b/mplex/shoes/services.js
@@ -84,21 +84,25 @@ class MultiplexorServices {
         container.innerHTML = '';
 
         this.services.forEach(service => {
-            const serviceActive = activeServices.includes(service.id);
+            // Determine if the service is currently active
+            const isActive = activeServices.includes(service.id);
+            console.debug('Render service card', service.id, 'active:', isActive);
 
             const card = document.createElement('div');
-            card.className = `card ${serviceActive ? 'bg-primary text-white' : ''}`;
+            card.className = `card ${isActive ? 'bg-primary text-white' : ''}`;
             card.style.cursor = 'pointer';
+            // persist state on the element so the handler can read it later
+            card.dataset.active = isActive;
 
             card.innerHTML = `
                 <div class="card-body p-3">
                     <div class="d-flex align-items-center">
-                        <span class="stamp stamp-md mr-3 ${serviceActive ? 'bg-white text-primary' : 'bg-primary'}">
+                        <span class="stamp stamp-md mr-3 ${isActive ? 'bg-white text-primary' : 'bg-primary'}">
                             <i class="${service.icon}"></i>
                         </span>
                         <div>
                             <h4 class="m-0">${service.name}</h4>
-                            <small class="${serviceActive ? 'text-white' : 'text-muted'}">${service.description}</small>
+                            <small class="${isActive ? 'text-white' : 'text-muted'}">${service.description}</small>
                         </div>
                     </div>
                 </div>
@@ -106,7 +110,9 @@ class MultiplexorServices {
 
             card.addEventListener('click', () => {
                 if (typeof onToggle === 'function') {
-                    onToggle(service, !serviceActive);
+                    const nextState = card.dataset.active !== 'true';
+                    console.debug('Toggle service', service.id, '->', nextState);
+                    onToggle(service, nextState);
                 }
             });
 


### PR DESCRIPTION
## Summary
- avoid runtime reference errors by managing service card state internally
- add debug logs for multiplexor service toggling

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688ba4c05c9c83259c45ff4098a18179