### PR TITLE
feat: add persistent audio stream proxy

### DIFF
--- a/backend/migrations/20250530000000_add_audio_stream_table.js
+++ b/backend/migrations/20250530000000_add_audio_stream_table.js
@@ -1,0 +1,31 @@
+const migrate_name = 'add-audio-stream-table';
+const logger = require('../logger').migrate;
+
+exports.up = function (knex) {
+    logger.info('[' + migrate_name + '] Migrating Up...');
+    return knex.schema
+        .createTable('audio_stream', (table) => {
+            table.increments().primary();
+            table.dateTime('created_on').notNull();
+            table.dateTime('modified_on').notNull();
+            table.integer('is_deleted').notNull().unsigned().defaultTo(0);
+            table.string('name').notNull();
+            table.string('alias').notNull();
+            table.string('url').notNull();
+            table.string('format').notNull().defaultTo('');
+            table.integer('bitrate').notNull().unsigned().defaultTo(0);
+            table.string('token_type').notNull().defaultTo('not_used');
+            table.string('token').notNull().defaultTo('');
+            table.string('token_mask').notNull().defaultTo('');
+            table.integer('buffer').notNull().unsigned().defaultTo(0);
+            table.string('category').notNull().defaultTo('');
+        })
+        .then(() => {
+            logger.info('[' + migrate_name + '] audio_stream Table created');
+        });
+};
+
+exports.down = function (knex) {
+    logger.info('[' + migrate_name + '] Migrating Down...');
+    return knex.schema.dropTable('audio_stream');
+};

--- a/backend/models/audio_stream.js
+++ b/backend/models/audio_stream.js
@@ -1,0 +1,39 @@
+const Model = require('objection').Model;
+const db = require('../db');
+const helpers = require('../lib/helpers');
+const now = require('./now_helper');
+
+Model.knex(db);
+
+const boolFields = ['is_deleted'];
+
+class AudioStream extends Model {
+    $beforeInsert() {
+        this.created_on = now();
+        this.modified_on = now();
+    }
+
+    $beforeUpdate() {
+        this.modified_on = now();
+    }
+
+    $parseDatabaseJson(json) {
+        json = super.$parseDatabaseJson(json);
+        return helpers.convertIntFieldsToBool(json, boolFields);
+    }
+
+    $formatDatabaseJson(json) {
+        json = helpers.convertBoolFieldsToInt(json, boolFields);
+        return super.$formatDatabaseJson(json);
+    }
+
+    static get name() {
+        return 'AudioStream';
+    }
+
+    static get tableName() {
+        return 'audio_stream';
+    }
+}
+
+module.exports = AudioStream;

--- a/frontend/js/app/audio-streams/main.ejs
+++ b/frontend/js/app/audio-streams/main.ejs
@@ -28,6 +28,7 @@
                     <thead>
                         <tr>
                             <th><%- i18n('str','source') %></th>
+                            <th><%- i18n('str','category') %></th>
                             <th><%- i18n('str','destination') %></th>
                             <th>&nbsp;</th>
                         </tr>

--- a/frontend/js/app/audio-streams/main.js
+++ b/frontend/js/app/audio-streams/main.js
@@ -110,6 +110,7 @@ module.exports = Mn.View.extend({
             const aliasLabel = stream.alias || stream.name;
             row.innerHTML    =
                 `<td><div class="wrap"><span class="tag host-link hover-purple" rel="${aliasUrl}">${aliasLabel}</span></div></td>` +
+                `<td>${stream.category || ''}</td>` +
                 `<td><div class="text-monospace"><span class="host-link" rel="${stream.url}">${stream.url}</span></div></td>` +
                 `<td class="text-right"><div class="btn-list">` +
                 `<button class="btn btn-sm btn-outline-primary play-stream mr-2" data-id="${stream.id}" title="${App.i18n('audio-streams','play')}"><i class="fe fe-play"></i></button>` +
@@ -124,11 +125,7 @@ module.exports = Mn.View.extend({
         if (!stream || !stream.url) {
             return '';
         }
-        // Если в адресе присутствует токен, используем проксированный путь
-        if (/token=/i.test(stream.url) || /signature=/i.test(stream.url)) {
-            return `/api/audio-streams/${stream.id}/play`;
-        }
-        return stream.url;
+        return `/api/audio-streams/${stream.id}/play`;
     },
 
     // Парсер текстовых плейлистов (M3U/M3U8/PLS)
@@ -190,6 +187,7 @@ module.exports = Mn.View.extend({
         const name  = prompt('Название потока:');
         const url   = name ? prompt('URL потока:') : null;
         const alias = name && url ? prompt('Алиас (опционально):', name.replace(/\s+/g, '').toLowerCase()) : null;
+        const category = name && url ? prompt('Категория (опционально):') : null;
         if (!name || !url) {
             return;
         }
@@ -197,7 +195,7 @@ module.exports = Mn.View.extend({
         fetch('/api/audio-streams', {
             method:  'POST',
             headers: {'Content-Type': 'application/json'},
-            body:    JSON.stringify({name: name, url: url, alias: alias || undefined})
+            body:    JSON.stringify({name: name, url: url, alias: alias || undefined, category: category || ''})
         })
             .then(res => res.json())
             .then(data => {

--- a/frontend/js/i18n/en-lang.json
+++ b/frontend/js/i18n/en-lang.json
@@ -206,6 +206,7 @@
     "destination": "Destination",
     "disable": "Disable",
     "disabled": "Disabled",
+    "category": "Category",
     "edit": "Edit",
     "email": "Email",
     "email-address": "Email address",

--- a/frontend/js/i18n/ru-lang.json
+++ b/frontend/js/i18n/ru-lang.json
@@ -206,6 +206,7 @@
     "destination": "Назначение",
     "disable": "Отключить",
     "disabled": "Отключено",
+    "category": "Категория",
     "edit": "Редактировать",
     "email": "Email",
     "email-address": "Email-адрес",


### PR DESCRIPTION
## Summary
- store audio streams in SQLite with new `audio_stream` table
- proxy stream playback through backend to avoid mixed content
- show stream category in UI and translations

## Testing
- `npm test` (backend) *(fails: Missing script "test")*
- `npm run validate-schema`
- `npm test` (frontend) *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688bb2239a5883259b47874aeb560c8d