### PR TITLE
feat: add edit modal for audio streams

### DIFF
--- a/frontend/js/app/audio-streams/edit.ejs
+++ b/frontend/js/app/audio-streams/edit.ejs
@@ -1,0 +1,36 @@
+<div class="modal-content">
+    <div class="modal-header">
+        <h5 class="modal-title"><%- i18n('str','edit') %></h5>
+        <button type="button" class="close cancel" aria-label="Close" data-dismiss="modal">&nbsp;</button>
+    </div>
+    <form>
+        <div class="modal-body">
+            <div class="form-group">
+                <label><%- i18n('audio-streams','alias') %></label>
+                <input type="text" class="form-control" name="alias" value="<%- alias %>">
+            </div>
+            <div class="form-group">
+                <label><%- i18n('audio-streams','link') %></label>
+                <input type="text" class="form-control" name="url" value="<%- url %>">
+            </div>
+            <div class="form-group">
+                <label><%- i18n('str','category') %></label>
+                <select name="category" class="form-control">
+                    <% categories.forEach(function(cat){ %>
+                        <option value="<%- cat %>" <%- category===cat?'selected':'' %>><%- i18n('audio-streams','category-'+cat) %></option>
+                    <% }) %>
+                </select>
+            </div>
+            <div class="form-group">
+                <label class="custom-control custom-checkbox">
+                    <input type="checkbox" class="custom-control-input" name="hide_token" <%- token_mask ? '' : 'checked' %>>
+                    <span class="custom-control-label"><%- i18n('audio-streams','hide-token') %></span>
+                </label>
+            </div>
+        </div>
+        <div class="modal-footer">
+            <button type="button" class="btn btn-secondary cancel" data-dismiss="modal"><%- i18n('str','cancel') %></button>
+            <button type="submit" class="btn btn-primary save"><%- i18n('str','save') %></button>
+        </div>
+    </form>
+</div>

--- a/frontend/js/app/audio-streams/edit.js
+++ b/frontend/js/app/audio-streams/edit.js
@@ -1,0 +1,53 @@
+const Mn  = require('backbone.marionette');
+const App = require('../main');
+const tpl = require('./edit.ejs');
+
+require('jquery-serializejson');
+
+const categories = ['news', 'music', 'talk', 'other'];
+
+module.exports = Mn.View.extend({
+    template:  tpl,
+    className: 'modal-dialog',
+
+    ui: {
+        form:    'form',
+        buttons: '.modal-footer button'
+    },
+
+    events: {
+        'submit @ui.form': 'onSubmit'
+    },
+
+    templateContext: function () {
+        return {
+            categories: categories
+        };
+    },
+
+    onSubmit: function (e) {
+        e.preventDefault();
+        const data = this.ui.form.serializeJSON();
+        // если выбрана опция скрытия токена, не используем token_mask
+        data.token_mask = data.hide_token ? '' : (this.model.get('token_mask') || '?token={token}');
+        delete data.hide_token;
+
+        const view = this;
+        this.ui.buttons.prop('disabled', true).addClass('btn-disabled');
+
+        fetch(`/api/audio-streams/${this.model.get('id')}`, {
+            method:  'PUT',
+            headers: {'Content-Type': 'application/json'},
+            body:    JSON.stringify(data)
+        })
+            .then(res => res.json())
+            .then(result => {
+                view.trigger('saved', result);
+                App.UI.closeModal();
+            })
+            .catch(err => {
+                console.error('Failed to update stream', err);
+                view.ui.buttons.prop('disabled', false).removeClass('btn-disabled');
+            });
+    }
+});

--- a/frontend/js/i18n/en-lang.json
+++ b/frontend/js/i18n/en-lang.json
@@ -262,7 +262,14 @@
     "delete-confirm": "Delete this stream?",
     "play": "Play",
     "save-m3u": "Save M3U",
-    "save-pls": "Save PLS"
+    "save-pls": "Save PLS",
+    "alias": "Alias",
+    "link": "Link",
+    "hide-token": "Hide token",
+    "category-news": "News",
+    "category-music": "Music",
+    "category-talk": "Talk",
+    "category-other": "Other"
   },
   "tls": {
     "certbot": "Certbot",

--- a/frontend/js/i18n/ru-lang.json
+++ b/frontend/js/i18n/ru-lang.json
@@ -262,7 +262,14 @@
     "delete-confirm": "Удалить этот источник?",
     "play": "Воспроизвести",
     "save-m3u": "Сохранить M3U",
-    "save-pls": "Сохранить PLS"
+    "save-pls": "Сохранить PLS",
+    "alias": "Алиас",
+    "link": "Ссылка",
+    "hide-token": "Спрятать токен",
+    "category-news": "Новости",
+    "category-music": "Музыка",
+    "category-talk": "Разговорное",
+    "category-other": "Другое"
   },
   "tls": {
     "certbot": "Certbot",


### PR DESCRIPTION
## Summary
- add edit button for audio streams with modal form
- allow updating alias, link, category and hide token flag
- add i18n strings for new fields

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688bbd789700832595a74a80c25d395b