### PR TITLE
feat: implement multiplexor settings editor

### DIFF
--- a/backend/routes/multiplexor.js
+++ b/backend/routes/multiplexor.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const path = require('path');
+const fs = require('fs');
 const childProcess = require('child_process');
 const parser = require('../lib/multiplexor-parser');
 
@@ -12,12 +13,28 @@ const MULTIPLEXOR_NAME = process.env.MULTIPLEXPOR_NAME || 'shoes';
 const CONFIG_PATH = process.env.MPLEX_CONFIG_PATH ||
     path.join(__dirname, `../../mplex/config/${MULTIPLEXOR_NAME}.yaml`);
 
+// Путь к описаниям доступных сервисов
+const SERVICES_PATH = process.env.MPLEX_SERVICES_PATH ||
+    path.join(__dirname, `../../mplex/${MULTIPLEXOR_NAME}/services.json`);
+
 /**
  * Получить текущую конфигурацию
  */
 router.get('/api/config', (req, res) => {
     const cfg = parser.loadConfig(CONFIG_PATH);
     res.json(cfg);
+});
+
+/**
+ * Получить список доступных сервисов
+ */
+router.get('/api/services', (req, res) => {
+    try {
+        const raw = fs.readFileSync(SERVICES_PATH, 'utf8');
+        res.json(JSON.parse(raw));
+    } catch (err) {
+        res.status(500).json({ services: [] });
+    }
 });
 
 /**

--- a/frontend/js/app/multiplexor/form.js
+++ b/frontend/js/app/multiplexor/form.js
@@ -1,15 +1,23 @@
 const $ = require('jquery');
+// Загрузка менеджера сервисов мультиплексора
+require('../../../../mplex/shoes/services');
+const services = window.multiplexorServices;
 
 /**
  * Добавляет строку для правила в форму
  * @param {string} [match=''] шаблон
  * @param {string} [forward=''] перенаправление
  */
-function addRuleRow(match = '', forward = '') {
+function addRuleRow(match = '', forward = '', serviceId = null) {
     const row = $('<div class="form-row rule-row mb-2"></div>');
-    row.append(`<div class="col"><input type="text" class="form-control rule-match" placeholder="match" value="${match}" /></div>`);
+    if (serviceId) {
+        row.attr('data-service-id', serviceId);
+    }
+    row.append(`<div class="col"><input type="text" class="form-control rule-match" placeholder="match" value="${match}" ${serviceId ? 'readonly' : ''} /></div>`);
     row.append(`<div class="col"><input type="text" class="form-control rule-forward" placeholder="forward" value="${forward}" /></div>`);
-    row.append('<div class="col-auto"><button type="button" class="btn btn-danger remove-rule">&times;</button></div>');
+    if (!serviceId) {
+        row.append('<div class="col-auto"><button type="button" class="btn btn-danger remove-rule">&times;</button></div>');
+    }
     $('#rules').append(row);
 }
 
@@ -23,7 +31,26 @@ module.exports = function initForm() {
             console.debug('Loaded config', cfg);
             $('#listen').val(cfg.listen || '');
             $('#rules').empty();
-            (cfg.rules || []).forEach(rule => addRuleRow(rule.match, rule.forward));
+            services.loadServices().then(() => {
+                const active = [];
+                (cfg.rules || []).forEach(rule => {
+                    const svc = services.getServiceByMatch(rule.match);
+                    if (svc) {
+                        active.push(svc.id);
+                        addRuleRow(svc.match, rule.forward || svc.defaultForward, svc.id);
+                    } else {
+                        addRuleRow(rule.match, rule.forward);
+                    }
+                });
+                const container = document.getElementById('services');
+                services.createServiceCards(container, active, (service, enabled) => {
+                    if (enabled) {
+                        addRuleRow(service.match, service.defaultForward, service.id);
+                    } else {
+                        $('#rules').find(`[data-service-id="${service.id}"]`).remove();
+                    }
+                });
+            });
         });
     }
 

--- a/frontend/js/app/multiplexor/main.ejs
+++ b/frontend/js/app/multiplexor/main.ejs
@@ -9,6 +9,10 @@
                     <label class="form-label">Порт для прослушивания</label>
                     <input type="text" id="listen" class="form-control" placeholder=":443" />
                 </div>
+                <div class="form-group" id="services-container">
+                    <label class="form-label">Доступные сервисы</label>
+                    <div id="services" class="row row-cards"></div>
+                </div>
                 <div class="form-group" id="rules-container">
                     <label class="form-label">Правила</label>
                     <div id="rules"></div>

--- a/mplex/shoes/services.js
+++ b/mplex/shoes/services.js
@@ -93,6 +93,7 @@ class MultiplexorServices {
             card.style.cursor = 'pointer';
             // persist state on the element so the handler can read it later
             card.dataset.active = isActive;
+            card.dataset.serviceId = service.id;
 
             card.innerHTML = `
                 <div class="card-body p-3">
@@ -109,8 +110,25 @@ class MultiplexorServices {
             `;
 
             card.addEventListener('click', () => {
+                const nextState = card.dataset.active !== 'true';
+                card.dataset.active = nextState;
+                card.classList.toggle('bg-primary', nextState);
+                card.classList.toggle('text-white', nextState);
+
+                const stamp = card.querySelector('.stamp');
+                if (stamp) {
+                    stamp.classList.toggle('bg-white', nextState);
+                    stamp.classList.toggle('text-primary', nextState);
+                    stamp.classList.toggle('bg-primary', !nextState);
+                }
+
+                const small = card.querySelector('small');
+                if (small) {
+                    small.classList.toggle('text-white', nextState);
+                    small.classList.toggle('text-muted', !nextState);
+                }
+
                 if (typeof onToggle === 'function') {
-                    const nextState = card.dataset.active !== 'true';
                     console.debug('Toggle service', service.id, '->', nextState);
                     onToggle(service, nextState);
                 }


### PR DESCRIPTION
## Summary
- expose multiplexor services via new backend API
- add service selection cards and rule syncing on editor page

## Testing
- `npm test` (backend) *(fails: Missing script)*
- `npm run validate-schema`
- `npm test` (frontend) *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688bcbe493c48325b1fc173a7988ff92