### PR TITLE
feat: add mikrotik integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,21 @@ so that the barrier for entry here is low.
 - fixed smaller issues/bugs
 - other small changes/improvements
 
+- Mikrotik integration for managing interfaces, containers and firewall
+
+## Mikrotik integration
+
+Environment variables used to connect to the router:
+
+- `MIKROTIK_HOST` – router address
+- `MIKROTIK_PORT` – API port (default 8728)
+- `MIKROTIK_USER` – username
+- `MIKROTIK_PASS` – password
+- `MIKROTIK_SSL` – set to `true` to use API-SSL
+- `MIKROTIK_SSH_PORT` – SSH port (default 22)
+
+Passwords, certificates and keys provided in the settings page are stored in `/data/mikrotik`.
+
 ## migration
 - **NOTE: migrating back to the original is not possible**, so make first a **backup** before migration, so you can use the backup to switch back
 - please delete all certs using dnspod as dns provider and recreate them after migration, since the certbot plugin used was replaced

--- a/backend/app.js
+++ b/backend/app.js
@@ -27,6 +27,7 @@ app.use(require('./lib/express/jwt')());
 app.use('/', require('./routes/main'));
 
 app.use('/multiplexor', require('./routes/multiplexor'));
+app.use('/mikrotik', require('./routes/mikrotik'));
 
 // production error handler
 // no stacktraces leaked to user

--- a/backend/lib/mikrotik.js
+++ b/backend/lib/mikrotik.js
@@ -1,0 +1,148 @@
+const fs = require('fs');
+const path = require('path');
+const { RouterOSClient } = require('node-routeros');
+const { Client: SSHClient } = require('ssh2');
+const log = require('../logger').mikrotik;
+
+const dataDir = '/data/mikrotik';
+
+/**
+ * Простая обёртка для работы с Mikrotik через API или SSH
+ */
+class Mikrotik {
+        constructor() {
+                this.host = process.env.MIKROTIK_HOST || '127.0.0.1';
+                this.port = parseInt(process.env.MIKROTIK_PORT || '8728', 10);
+                this.username = process.env.MIKROTIK_USER || 'admin';
+                this.password = process.env.MIKROTIK_PASS || '';
+                this.ssl = process.env.MIKROTIK_SSL === 'true';
+                this.sshPort = parseInt(process.env.MIKROTIK_SSH_PORT || '22', 10);
+        }
+
+        /**
+         * Клиент RouterOS API
+         */
+        _apiClient() {
+                return new RouterOSClient({
+                        host: this.host,
+                        user: this.username,
+                        password: this.password,
+                        port: this.port,
+                        ssl: this.ssl,
+                });
+        }
+
+        async _withClient(fn) {
+                const client = this._apiClient();
+                await client.connect();
+                try {
+                        return await fn(client);
+                } finally {
+                        client.close();
+                }
+        }
+
+        /**
+         * Список интерфейсов
+         */
+        async getInterfaces() {
+                log.info('Запрос списка интерфейсов');
+                return this._withClient(client => client.menu('/interface').getAll());
+        }
+
+        /**
+         * Список контейнеров
+         */
+        async getContainers() {
+                log.info('Запрос списка контейнеров');
+                return this._withClient(client => client.menu('/container').getAll());
+        }
+
+        /**
+         * Список правил файрвола
+         */
+        async getFirewall() {
+                log.info('Запрос правил файрвола');
+                return this._withClient(client => client.menu('/ip/firewall/filter').getAll());
+        }
+
+        /**
+         * Добавление IP в чёрный список
+         */
+        async addToBlacklist(address) {
+                log.info('Добавление %s в blacklist', address);
+                return this._withClient(client => client.menu('/ip/firewall/address-list').add({
+                        list: 'blacklist',
+                        address: address,
+                }));
+        }
+
+        /**
+         * Создание нового контейнера
+         */
+        async createContainer(opts) {
+                log.info('Создание контейнера %s', opts.name);
+                return this._withClient(client => client.menu('/container').add({
+                        name: opts.name,
+                        'remote-image': opts.image,
+                        'root-dir': opts.rootDir || `/var/lib/${opts.name}`,
+                        interface: opts.interface,
+                        start: 'yes',
+                }));
+        }
+
+        /**
+         * Выполнение произвольной команды по SSH
+         */
+        runSSH(cmd) {
+                log.info('SSH команда: %s', cmd);
+                return new Promise((resolve, reject) => {
+                        const conn = new SSHClient();
+                        const options = {
+                                host: this.host,
+                                port: this.sshPort,
+                                username: this.username,
+                                password: this.password,
+                        };
+                        const keyFile = path.join(dataDir, 'id_rsa');
+                        if (fs.existsSync(keyFile)) {
+                                options.privateKey = fs.readFileSync(keyFile);
+                        }
+                        conn.on('ready', () => {
+                                conn.exec(cmd, (err, stream) => {
+                                        if (err) {
+                                                conn.end();
+                                                return reject(err);
+                                        }
+                                        let data = '';
+                                        stream.on('close', () => {
+                                                conn.end();
+                                                resolve(data);
+                                        }).on('data', chunk => {
+                                                data += chunk.toString();
+                                        }).stderr.on('data', chunk => {
+                                                log.warn('SSH stderr: %s', chunk.toString());
+                                        });
+                                });
+                        }).on('error', reject).connect(options);
+                });
+        }
+
+        saveCredentials(creds) {
+                if (!fs.existsSync(dataDir)) {
+                        fs.mkdirSync(dataDir, { recursive: true });
+                }
+                fs.writeFileSync(path.join(dataDir, 'credentials.json'), JSON.stringify(creds, null, 2), 'utf8');
+        }
+
+        loadCredentials() {
+                try {
+                        const raw = fs.readFileSync(path.join(dataDir, 'credentials.json'), 'utf8');
+                        return JSON.parse(raw);
+                } catch (err) {
+                        return {};
+                }
+        }
+}
+
+module.exports = new Mikrotik();

--- a/backend/logger.js
+++ b/backend/logger.js
@@ -13,4 +13,5 @@ module.exports = {
         ip_ranges: new Signale({ scope: 'IP Ranges' }),
         oidc: new Signale({ scope: 'OIDC     ' }),
         audio: new Signale({ scope: 'Audio    ' }),
+        mikrotik: new Signale({ scope: 'Mikrotik ' }),
 };

--- a/backend/package.json
+++ b/backend/package.json
@@ -22,13 +22,15 @@
     "lodash": "4.17.21",
     "moment": "2.30.1",
     "mysql2": "3.14.1",
+    "node-routeros": "1.6.9",
     "node-rsa": "1.1.1",
-    "openid-client": "6.6.1",
     "objection": "3.1.5",
+    "openid-client": "6.6.1",
     "path": "0.12.7",
     "pg": "8.16.2",
     "punycode": "2.3.1",
-    "signale": "1.4.0"
+    "signale": "1.4.0",
+    "ssh2": "1.16.0"
   },
   "author": "Jamie Curnow <jc@jc21.com> and ZoeyVid <zoeyvid@zvcdn.de>",
   "license": "MIT",

--- a/backend/routes/mikrotik.js
+++ b/backend/routes/mikrotik.js
@@ -1,0 +1,80 @@
+const express = require('express');
+const mikrotik = require('../lib/mikrotik');
+const log = require('../logger').mikrotik;
+
+const router = express.Router({
+        caseSensitive: true,
+        strict: true,
+        mergeParams: true,
+});
+
+// Список интерфейсов
+router.get('/interfaces', async (req, res) => {
+        try {
+                const data = await mikrotik.getInterfaces();
+                res.json(data);
+        } catch (err) {
+                log.error('Ошибка получения интерфейсов', err);
+                res.status(500).send({ error: 'mikrotik error' });
+        }
+});
+
+// Список контейнеров
+router.get('/containers', async (req, res) => {
+        try {
+                const data = await mikrotik.getContainers();
+                res.json(data);
+        } catch (err) {
+                log.error('Ошибка получения контейнеров', err);
+                res.status(500).send({ error: 'mikrotik error' });
+        }
+});
+
+// Создание контейнера
+router.post('/containers', async (req, res) => {
+        try {
+                await mikrotik.createContainer(req.body || {});
+                res.json({ status: 'ok' });
+        } catch (err) {
+                log.error('Ошибка создания контейнера', err);
+                res.status(500).send({ error: 'mikrotik error' });
+        }
+});
+
+// Правила файрвола
+router.get('/firewall', async (req, res) => {
+        try {
+                const data = await mikrotik.getFirewall();
+                res.json(data);
+        } catch (err) {
+                log.error('Ошибка получения правил', err);
+                res.status(500).send({ error: 'mikrotik error' });
+        }
+});
+
+// Добавление в blacklist
+router.post('/firewall/blacklist', async (req, res) => {
+        const addr = req.body && req.body.address;
+        if (!addr) {
+                return res.status(400).send({ error: 'address required' });
+        }
+        try {
+                await mikrotik.addToBlacklist(addr);
+                res.json({ status: 'ok' });
+        } catch (err) {
+                log.error('Ошибка добавления в blacklist', err);
+                res.status(500).send({ error: 'mikrotik error' });
+        }
+});
+
+// Работа с учётными данными
+router.get('/credentials', (req, res) => {
+        res.json(mikrotik.loadCredentials());
+});
+
+router.post('/credentials', (req, res) => {
+        mikrotik.saveCredentials(req.body || {});
+        res.json({ status: 'ok' });
+});
+
+module.exports = router;

--- a/frontend/html/mikrotik.ejs
+++ b/frontend/html/mikrotik.ejs
@@ -1,0 +1,46 @@
+<% var title = 'Mikrotik – NPMplus' %>
+<%- include partials/header.ejs %>
+
+<div class="page" id="mikrotik" data-version="<%= version %>">
+        <div class="container">
+                <h2>Mikrotik</h2>
+                <form id="creds-form">
+                        <div class="mb-3">
+                                <label class="form-label">Host</label>
+                                <input type="text" id="host" class="form-control" />
+                        </div>
+                        <div class="mb-3">
+                                <label class="form-label">Пользователь</label>
+                                <input type="text" id="user" class="form-control" />
+                        </div>
+                        <div class="mb-3">
+                                <label class="form-label">Пароль</label>
+                                <input type="password" id="pass" class="form-control" />
+                        </div>
+                        <div class="mb-3">
+                                <label class="form-label">SSL</label>
+                                <input type="checkbox" id="ssl" />
+                        </div>
+                        <button type="button" id="save" class="btn btn-primary">Сохранить</button>
+                </form>
+                <hr />
+                <form id="container-form">
+                        <div class="mb-3">
+                                <label class="form-label">Имя контейнера</label>
+                                <input type="text" id="cname" class="form-control" />
+                        </div>
+                        <div class="mb-3">
+                                <label class="form-label">Интерфейс</label>
+                                <input type="text" id="iface" class="form-control" />
+                        </div>
+                        <div class="mb-3">
+                                <label class="form-label">Порты</label>
+                                <input type="text" id="ports" class="form-control" placeholder="8080:80" />
+                        </div>
+                        <button type="button" id="create" class="btn btn-success">Создать контейнер</button>
+                </form>
+        </div>
+</div>
+
+<script type="text/javascript" src="/js/mikrotik.bundle.js?v=<%= version %>"></script>
+<%- include partials/footer.ejs %>

--- a/frontend/js/mikrotik.js
+++ b/frontend/js/mikrotik.js
@@ -1,0 +1,30 @@
+$(document).ready(() => {
+        $('#save').on('click', async () => {
+                const payload = {
+                        host: $('#host').val(),
+                        user: $('#user').val(),
+                        pass: $('#pass').val(),
+                        ssl: $('#ssl').is(':checked'),
+                };
+                await fetch('/mikrotik/credentials', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify(payload),
+                });
+                alert('Сохранено');
+        });
+
+        $('#create').on('click', async () => {
+                const payload = {
+                        name: $('#cname').val(),
+                        interface: $('#iface').val(),
+                        ports: $('#ports').val(),
+                };
+                await fetch('/mikrotik/containers', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify(payload),
+                });
+                alert('Контейнер создан');
+        });
+});

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -8,8 +8,9 @@ const PACKAGE              = require('./package.json');
 
 module.exports = {
 	entry:     {
-		main:  './js/index.js',
-		login: './js/login.js'
+                main:  './js/index.js',
+                login: './js/login.js',
+                mikrotik: './js/mikrotik.js'
 	},
 	output:    {
 		path:          path.resolve(__dirname, 'dist'),
@@ -137,14 +138,22 @@ module.exports = {
 				version: PACKAGE.version
 			}
 		}),
-		new HtmlWebpackPlugin({
-			template:           '!!ejs-webpack-loader!html/login.ejs',
-			filename:           'login.html',
-			inject:             false,
-			templateParameters: {
-				version: PACKAGE.version
-			}
-		}),
+                new HtmlWebpackPlugin({
+                        template:           '!!ejs-webpack-loader!html/login.ejs',
+                        filename:           'login.html',
+                        inject:             false,
+                        templateParameters: {
+                                version: PACKAGE.version
+                        }
+                }),
+                new HtmlWebpackPlugin({
+                        template:           '!!ejs-webpack-loader!html/mikrotik.ejs',
+                        filename:           'mikrotik.html',
+                        inject:             false,
+                        templateParameters: {
+                                version: PACKAGE.version
+                        }
+                }),
 		new MiniCssExtractPlugin({
 			filename:      'css/[name].css',
 			chunkFilename: 'css/[id].css'


### PR DESCRIPTION
## Summary
- add backend client and routes for MikroTik (API, SSL, SSH)
- expose MikroTik controls in frontend with separate page
- document MIKROTIK_* environment variables

## Testing
- `npm run validate-schema`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688bd49935f08325b8691344a60957a3