### PR TITLE
feat: add multiplexor service page

### DIFF
--- a/metronic/src/components/multiplexor/service-card-list.tsx
+++ b/metronic/src/components/multiplexor/service-card-list.tsx
@@ -1,0 +1,66 @@
+import { useEffect, useState } from 'react';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardTitle,
+} from '@/components/ui/card';
+import { multiplexorServices, type Service } from '@/lib/multiplexor-services';
+
+interface Props {
+  onToggle?: (service: Service, active: boolean) => void;
+}
+
+/**
+ * Список карточек сервисов мультиплексора
+ * Отображает доступные сервисы и позволяет их переключать
+ */
+export function ServiceCardList({ onToggle }: Props) {
+  const [services, setServices] = useState<Service[]>([]);
+  const [active, setActive] = useState<string[]>([]);
+
+  // Загружаем сервисы при монтировании компонента
+  useEffect(() => {
+    multiplexorServices.loadServices().then(setServices);
+  }, []);
+
+  // Обработчик переключения состояния сервиса
+  const handleToggle = (service: Service) => {
+    const isActive = active.includes(service.id);
+    const newActive = isActive
+      ? active.filter((id) => id !== service.id)
+      : [...active, service.id];
+
+    setActive(newActive);
+    console.log(`Сервис ${service.id} теперь ${isActive ? 'выключен' : 'включен'}`);
+    onToggle?.(service, !isActive);
+  };
+
+  return (
+    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      {services.map((s) => (
+        <Card
+          key={s.id}
+          className={`cursor-pointer transition-colors ${
+            active.includes(s.id) ? 'bg-primary text-white' : ''
+          }`}
+          onClick={() => handleToggle(s)}
+        >
+          <CardContent className="flex items-center gap-3 p-4">
+            <span className="text-2xl">
+              <i className={s.icon}></i>
+            </span>
+            <div>
+              <CardTitle>{s.name}</CardTitle>
+              <CardDescription
+                className={active.includes(s.id) ? 'text-white/80' : ''}
+              >
+                {s.description}
+              </CardDescription>
+            </div>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/metronic/src/lib/multiplexor-services.ts
+++ b/metronic/src/lib/multiplexor-services.ts
@@ -1,0 +1,72 @@
+// Класс управления сервисами мультиплексора
+// Загружает список сервисов с API и предоставляет методы для работы с ними
+
+export interface Service {
+  id: string;
+  name: string;
+  description: string;
+  match: string;
+  defaultForward: string;
+  icon: string;
+  forward?: string; // Настраиваемый адрес переадресации
+}
+
+class MultiplexorServices {
+  private services: Service[] = [];
+  private loaded = false;
+
+  /**
+   * Загружает список сервисов с сервера
+   */
+  async loadServices(): Promise<Service[]> {
+    if (this.loaded) {
+      return this.services;
+    }
+
+    try {
+      const resp = await fetch('/multiplexor/api/services');
+      const data = await resp.json();
+      this.services = data.services as Service[];
+      this.loaded = true;
+      console.log('Сервисы мультиплексора загружены', this.services);
+    } catch (error) {
+      console.error('Ошибка загрузки сервисов:', error);
+    }
+
+    return this.services;
+  }
+
+  /** Получает сервис по идентификатору */
+  getById(id: string): Service | undefined {
+    return this.services.find((s) => s.id === id);
+  }
+
+  /** Получает сервис по шаблону */
+  getByMatch(match: string): Service | undefined {
+    return this.services.find((s) => s.match === match);
+  }
+
+  /**
+   * Преобразует правило в сервис
+   * @param rule объект с полями match и forward
+   */
+  ruleToService(rule: { match: string; forward: string }): Service {
+    const service = this.getByMatch(rule.match);
+    if (service) {
+      return { ...service, forward: rule.forward };
+    }
+
+    // Пользовательское правило
+    return {
+      id: 'custom',
+      name: 'Пользовательское правило',
+      description: `${rule.match} → ${rule.forward}`,
+      match: rule.match,
+      defaultForward: rule.forward,
+      forward: rule.forward,
+      icon: 'fe-code',
+    };
+  }
+}
+
+export const multiplexorServices = new MultiplexorServices();

--- a/metronic/src/pages/network/index.ts
+++ b/metronic/src/pages/network/index.ts
@@ -1,3 +1,4 @@
 export * from './get-started/network-basic-page';
 export * from './user-cards';
 export * from './user-table';
+export * from './multiplexor';

--- a/metronic/src/pages/network/multiplexor/index.ts
+++ b/metronic/src/pages/network/multiplexor/index.ts
@@ -1,0 +1,1 @@
+export * from './network-basic-page';

--- a/metronic/src/pages/network/multiplexor/network-basic-page.tsx
+++ b/metronic/src/pages/network/multiplexor/network-basic-page.tsx
@@ -1,0 +1,17 @@
+import { Fragment } from 'react';
+import { Container } from '@/components/common/container';
+import { ServiceCardList } from '@/components/multiplexor/service-card-list';
+
+/**
+ * Страница управления сервисами мультиплексора
+ * Показывает список сервисов и позволяет их активировать
+ */
+export function NetworkMultiplexorPage() {
+  return (
+    <Fragment>
+      <Container>
+        <ServiceCardList onToggle={(s, active) => console.log('Toggle', s.id, active)} />
+      </Container>
+    </Fragment>
+  );
+}

--- a/metronic/src/routing/app-routing-setup.tsx
+++ b/metronic/src/routing/app-routing-setup.tsx
@@ -56,6 +56,7 @@ import {
   NetworkUserCardsTeamCrewPage,
   NetworkUserTableTeamCrewPage,
   NetworkVisitorsPage,
+  NetworkMultiplexorPage,
 } from '@/pages/network';
 import {
   CampaignsCardPage,
@@ -290,6 +291,7 @@ export function AppRoutingSetup() {
             path="/network/get-started"
             element={<NetworkGetStartedPage />}
           />
+          <Route path="/network/multiplexor" element={<NetworkMultiplexorPage />} />
           <Route
             path="/network/user-cards/mini-cards"
             element={<NetworkMiniCardsPage />}


### PR DESCRIPTION
## Summary
- add MultiplexorServices class and React components
- expose multiplexor page and route in network section

## Testing
- `npx eslint src/lib/multiplexor-services.ts src/components/multiplexor/service-card-list.tsx src/pages/network/multiplexor/network-basic-page.tsx src/pages/network/index.ts src/routing/app-routing-setup.tsx`
- `yarn build` (fails: Could not resolve "./backup-and-recovery/account-basic-page" from "src/pages/account/security/index.ts")

------
https://chatgpt.com/codex/tasks/task_e_688ba1e5f6e88325bd33e1a7a395cc7d