### PR TITLE
feat: добавить редактор настроек мультиплексора

### DIFF
--- a/backend/lib/multiplexor-parser.js
+++ b/backend/lib/multiplexor-parser.js
@@ -3,31 +3,83 @@ const yaml = require('js-yaml');
 const logger = require('../logger').express;
 
 /**
+ * Преобразует структуру Shoes Multiplexor в упрощённый объект формы
+ * @param {Array|Object} data исходная структура из YAML
+ * @returns {{listen: string, rules: Array}} объект формы
+ */
+function normalize(data) {
+    const first = Array.isArray(data) ? data[0] : data || {};
+
+    // Адрес прослушивания
+    const listen = first.address || '';
+
+    // Каждое правило сводим к {match, forward}
+    const rules = (((first.protocol || {}).rules) || []).map(rule => ({
+        match: (rule.lpn && rule.lpn[0]) || (rule.sni && rule.sni[0]) || '',
+        forward: rule.target || ''
+    }));
+
+    return { listen, rules };
+}
+
+/**
+ * Преобразует объект формы в структуру Shoes Multiplexor
+ * @param {{listen: string, rules: Array}} formData данные формы
+ * @returns {Array} структура для YAML
+ */
+function denormalize(formData) {
+    return [{
+        address: formData.listen || '',
+        transport: 'tcp',
+        protocol: {
+            type: 'http',
+            rules: (formData.rules || []).map(r => {
+                const rule = {
+                    name: r.match || 'rule',
+                    target: r.forward || ''
+                };
+
+                // Выбираем тип сопоставления: SNI для доменов, LPN для остального
+                if (r.match && r.match.includes('.')) {
+                    rule.sni = [r.match];
+                } else {
+                    rule.lpn = [r.match];
+                }
+
+                return rule;
+            })
+        }
+    }];
+}
+
+/**
  * Загружает конфигурацию мультиплексора из YAML-файла
  * @param {string} filePath путь к файлу конфигурации
- * @returns {object} объект конфигурации
+ * @returns {object} объект конфигурации для формы
  */
 function loadConfig(filePath) {
     try {
         const raw = fs.readFileSync(filePath, 'utf8');
-        const data = yaml.load(raw) || {};
+        const yamlData = yaml.load(raw) || {};
+        const cfg = normalize(yamlData);
         logger.info(`Loaded multiplexor config from ${filePath}`);
-        return data;
+        return cfg;
     } catch (err) {
         logger.error(`Failed to read multiplexor config: ${err.message}`);
-        return {};
+        return { listen: '', rules: [] };
     }
 }
 
 /**
  * Сохраняет объект конфигурации в YAML-файл
  * @param {string} filePath путь к файлу конфигурации
- * @param {object} data данные для сохранения
+ * @param {object} data данные формы для сохранения
  * @returns {boolean} успех операции
  */
 function saveConfig(filePath, data) {
     try {
-        const content = yaml.dump(data, { noRefs: true });
+        const yamlData = denormalize(data);
+        const content = yaml.dump(yamlData, { noRefs: true });
         fs.writeFileSync(filePath, content, 'utf8');
         logger.info(`Saved multiplexor config to ${filePath}`);
         return true;

--- a/backend/routes/multiplexor.js
+++ b/backend/routes/multiplexor.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const path = require('path');
+const fs = require('fs');
 const childProcess = require('child_process');
 const parser = require('../lib/multiplexor-parser');
 
@@ -12,12 +13,27 @@ const MULTIPLEXOR_NAME = process.env.MULTIPLEXPOR_NAME || 'shoes';
 const CONFIG_PATH = process.env.MPLEX_CONFIG_PATH ||
     path.join(__dirname, `../../mplex/config/${MULTIPLEXOR_NAME}.yaml`);
 
+// Путь к описаниям сервисов
+const SERVICES_PATH = path.join(__dirname, `../../mplex/${MULTIPLEXOR_NAME}/services.json`);
+
 /**
  * Получить текущую конфигурацию
  */
 router.get('/api/config', (req, res) => {
     const cfg = parser.loadConfig(CONFIG_PATH);
     res.json(cfg);
+});
+
+/**
+ * Список доступных сервисов
+ */
+router.get('/api/services', (req, res) => {
+    try {
+        const services = JSON.parse(fs.readFileSync(SERVICES_PATH, 'utf8'));
+        res.json(services);
+    } catch (err) {
+        res.status(500).json({ services: [] });
+    }
 });
 
 /**


### PR DESCRIPTION
## Summary
- преобразован yaml-шаблон multiplexer в удобный объект формы
- добавлен эндпоинт для списка сервисов мультиплексора
- реализовано хранение и сбор данных правил на клиенте

## Testing
- `npm --prefix backend test` *(missing script)*
- `npm --prefix frontend test` *(missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688bdcd8d8bc8325a8e384765a5a20b3