### PR TITLE
Добавлен пример использования cs-mikrotik-bouncer-alt

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ labels:
 8. use the output of step 5 as `API_KEY`
 9. save the file
 10. redeploy the `compose.yaml`
+11. Для блокировки подозрительных подключений на MikroTik можно добавить контейнер [cs-mikrotik-bouncer-alt](https://github.com/nvtkaszpir/cs-mikrotik-bouncer-alt). Пример конфигурации приведён в `compose.yaml`, в переменной `CROWDSEC_BOUNCER_API_KEY` указывается ключ из шага 5.
 
 # coreruleset plugins
 1. Download the plugin (all files inside the `plugins` folder of the git repo), most time: `<plugin-name>-before.conf`, `<plugin-name>-config.conf` and `<plugin-name>-after.conf` and sometimes `<plugin-name>.data` and/or `<plugin-name>.lua` or somilar files

--- a/compose.yaml
+++ b/compose.yaml
@@ -146,6 +146,20 @@ services:
 #      - "./opt/openappsec/logs:/opt/openappsec/logs:ro" # only uncomment if you also use the openappsec-agent container
 #      #- "./opt/npmplus/services/crowdsec.yaml:/etc/crowdsec/config.yaml"
 
+# This optional bouncer передаёт решения CrowdSec в MikroTik для блокировки IP
+#  mikrotik-bouncer:
+#    image: ghcr.io/nvtkaszpir/cs-mikrotik-bouncer-alt:latest
+#    container_name: mikrotik-bouncer
+#    restart: always
+#    environment:
+#      - "TZ=Europe/Moscow" # needs to be changed
+#      - "CROWDSEC_BOUNCER_API_KEY=<api-key>" # ключ из cscli bouncers add
+#      - "CROWDSEC_URL=http://crowdsec:8080/"
+#      - "MIKROTIK_HOST=192.168.88.1:8728" # адрес и порт роутера
+#      - "MIKROTIK_USER=crowdsec-bouncer-user"
+#      - "MIKROTIK_PASS=<password>"
+#      - "MIKROTIK_TLS=false"
+
 # This can be used with GOA=true, to keep the geopip database updated, you need to change the envs to make it work
 #  geoipupdate:
 #    container_name: npmplus-geoipupdate

--- a/services.json
+++ b/services.json
@@ -5,6 +5,11 @@
     "config": "/services/crowdsec.yaml"
   },
   {
+    "id": "mikrotik-bouncer",
+    "name": "MikroTik Bouncer",
+    "config": "/services/mikrotik-bouncer.env"
+  },
+  {
     "id": "caddy",
     "name": "Caddy Redirect",
     "config": "/services/Caddyfile"


### PR DESCRIPTION
## Summary
- добавлен пример контейнера cs-mikrotik-bouncer-alt для блокировок Mikrotik
- описано подключение бонcера в README
- добавлен сервис Mikrotik Bouncer в services.json

## Testing
- `npm test` (ожидаемо: нет package.json)
- `cd backend && npm run validate-schema`
- `node -e "require('./services.json'); console.log('ok')"`

------
https://chatgpt.com/codex/tasks/task_e_689ce511d08083259014aae56536f124